### PR TITLE
初始化sql语句中字段双引号改成单引号

### DIFF
--- a/source-code/basis/jpa-demo/src/test/resources/init.sql
+++ b/source-code/basis/jpa-demo/src/test/resources/init.sql
@@ -1,14 +1,14 @@
-insert into person (name, age,company_id,school_id)  values ("person1",18,1,1)
-insert into person (name, age,company_id,school_id)  values ("person2",18,1,1)
-insert into person (name, age,company_id,school_id)  values ("person3",15,1,1)
-insert into person (name, age,company_id,school_id)  values ("person4",18,2,2)
-insert into person (name, age,company_id,school_id)  values ("person5",16,2,2)
-insert into person (name, age,company_id,school_id)  values ("person6",19,2,2)
+insert into person (name,age,company_id,school_id)  values ('person1',18,1,1)
+insert into person (name,age,company_id,school_id)  values ('person2',18,1,1)
+insert into person (name,age,company_id,school_id)  values ('person3',15,1,1)
+insert into person (name,age,company_id,school_id)  values ('person4',18,2,2)
+insert into person (name,age,company_id,school_id)  values ('person5',16,2,2)
+insert into person (name,age,company_id,school_id)  values ('person6',19,2,2)
 
 
-insert into company (company_name, description) values ("tw","tw is good")
-insert into company (company_name, description) values ("baidu","baidu is good")
+insert into company (company_name, description) values ('tw','tw is good')
+insert into company (company_name, description) values ('baidu','baidu is good')
 
-insert into school (name, description) values ("zhongnandaxue","zhongnandaxue is good")
-insert into school (name, description) values ("hubeidaxue","hubeidaxue is good")
+insert into school (name, description) values ('zhongnandaxue','zhongnandaxue is good')
+insert into school (name, description) values ('hubeidaxue','hubeidaxue is good')
 


### PR DESCRIPTION
将 `jpa-demo` 中初始化 `sql` 中属性字符串双引号改成了单引号。双引号在运行后，会提示`can not find column xxx(eg: person1)`